### PR TITLE
Adds support for remote server with (and without) API key / Universal Render Pipeline support

### DIFF
--- a/Assets/Stable-Diffusion-Unity-Integration/Scripts/SDSettings.cs
+++ b/Assets/Stable-Diffusion-Unity-Integration/Scripts/SDSettings.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -9,6 +7,7 @@ using UnityEngine;
 /// </summary>
 public class SDSettings : ScriptableObject
 {
+    [Header("AUTOMATIC1111 Settings")]
     public string StableDiffusionServerURL = "http://127.0.0.1:7860";
     public string ModelsAPI = "/sdapi/v1/sd-models";
     public string TextToImageAPI = "/sdapi/v1/txt2img";
@@ -16,13 +15,20 @@ public class SDSettings : ScriptableObject
     public string OptionAPI = "/sdapi/v1/options";
     public string ProgressAPI = "/sdapi/v1/progress";
     public string OutputFolder = "/streamingAssets";
-
     public string sampler = "Euler a";
     public int width = 512;
     public int height = 512;
     public int steps = 35;
     public float cfgScale = 7;
     public long seed = -1;
+    
+    [Header("API Settings")]
+    public bool useAuth = false;
+    public string user = "";
+    public string pass = "";
+    
+    [Header("URP Settings")]
+    public bool useUniversalRenderPipeline = false;
 }
 
 /// <summary>

--- a/Assets/Stable-Diffusion-Unity-Integration/Scripts/StableDiffusionGenerator.cs
+++ b/Assets/Stable-Diffusion-Unity-Integration/Scripts/StableDiffusionGenerator.cs
@@ -1,14 +1,18 @@
+using System;
 using Newtonsoft.Json;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Networking;
 
 public class StableDiffusionGenerator : MonoBehaviour
 {
     static protected StableDiffusionConfiguration sdc = null;
-
+    private Coroutine _updateProgressRunning = null;
+    
     /// <summary>
     /// Update a generation progress bar
     /// </summary>
@@ -34,6 +38,42 @@ public class StableDiffusionGenerator : MonoBehaviour
 #endif
     }
 
+    /// <summary>
+    /// Update a generation progress bar with auth
+    /// </summary>
+    protected void UpdateGenerationProgressWithAuth()
+    {
+        #if UNITY_EDITOR
+            if (_updateProgressRunning != null) return;
+            _updateProgressRunning = StartCoroutine(UpdateGenerationProgressWithAuthCor());
+        #endif
+    }
+    
+    private IEnumerator UpdateGenerationProgressWithAuthCor()
+    {
+        // Stable diffusion API url for setting a model
+        string url = sdc.settings.StableDiffusionServerURL + sdc.settings.ProgressAPI;
+        float progress = 0;
+
+        using (UnityWebRequest modelInfoRequest = UnityWebRequest.Get(url))
+        {
+            byte[] bytesToEncode = Encoding.UTF8.GetBytes(sdc.settings.user + ":" + sdc.settings.pass);
+            string encodedText = Convert.ToBase64String(bytesToEncode);
+
+            modelInfoRequest.SetRequestHeader("Authorization", "Basic " + encodedText);
+            yield return modelInfoRequest.SendWebRequest();
+
+            // Deserialize the response to a class
+            SDProgress sdp = JsonConvert.DeserializeObject<SDProgress>(modelInfoRequest.downloadHandler.text);
+            progress = sdp.progress;
+
+            EditorUtility.DisplayProgressBar("Generation in progress", progress * 100 + "%", progress);
+        }
+
+        _updateProgressRunning = null;
+        yield return null;
+    }
+    
     /// <summary>
     /// Find all the game objects that contains a certain component type.
     /// </summary>

--- a/Assets/Stable-Diffusion-Unity-Integration/Scripts/StableDiffusionImage2Image.cs
+++ b/Assets/Stable-Diffusion-Unity-Integration/Scripts/StableDiffusionImage2Image.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using UnityEngine;
 using System.Linq;
+using System.Text;
 using UnityEngine.UI;
 using System.Threading.Tasks;
 
@@ -199,6 +200,15 @@ public class StableDiffusionImage2Image: StableDiffusionGenerator
             httpWebRequest.ContentType = "application/json";
             httpWebRequest.Method = "POST";
 
+            // add auth-header to request
+            if (sdc.settings.useAuth && !sdc.settings.user.Equals("") && !sdc.settings.pass.Equals(""))
+            {
+                httpWebRequest.PreAuthenticate = true;
+                byte[] bytesToEncode = Encoding.UTF8.GetBytes(sdc.settings.user + ":" + sdc.settings.pass);
+                string encodedCredentials = Convert.ToBase64String(bytesToEncode);
+                httpWebRequest.Headers.Add("Authorization", "Basic " + encodedCredentials);
+            }
+            
             // Send the generation parameters along with the POST request
             using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
             {
@@ -238,8 +248,16 @@ public class StableDiffusionImage2Image: StableDiffusionGenerator
             Task<WebResponse> t = httpWebRequest.GetResponseAsync();
             while (!t.IsCompleted)
             {
-                UpdateGenerationProgress();
-                yield return new WaitForSeconds(0.5f);
+                if (sdc.settings.useAuth && !sdc.settings.user.Equals("") && !sdc.settings.pass.Equals(""))
+                {
+                    UpdateGenerationProgressWithAuth();
+                    yield return new WaitForSeconds(0.5f);
+                }
+                else
+                {
+                    UpdateGenerationProgress();
+                    yield return new WaitForSeconds(0.5f);
+                }
             }
 
             var httpResponse = t.Result;


### PR DESCRIPTION
#### Adds support for remote server with (and without) API key
- supports Image2Image
- supports Text2Image
- supports Text2Material

#### Support for Universal Render Pipeline
- adds toggle to generate "Universal Render Pipeline" materials
- supports Text2Material

#### Setup AUTOMATIC1111
- set COMMANDLINE_ARGS=--listen --api --api-auth user:pass --cors-allow-origins=*

#### Setup Unity
- on Stable-Diffusion-Unity-Integration / Settings / DefaultLocalSDSettings
- enable useAuth
- add user
- add pass